### PR TITLE
fix(web): api errors weren't been displayed on client side

### DIFF
--- a/apps/web/src/app/actions/auth/auth.action.ts
+++ b/apps/web/src/app/actions/auth/auth.action.ts
@@ -1,30 +1,57 @@
-'use server'
+"use server";
 
-import { ApiClient } from "../api/api-client"
+import { ApiError } from "next/dist/server/api-utils";
+import { ApiClient } from "../api/api-client";
 import { saveSessionAction } from "../session/session.action";
-import { AuthRequestDto } from "./dtos/auth.request.dto"
-import { AuthResponseDto } from "./dtos/auth.response.dto"
+import { AuthRequestDto } from "./dtos/auth.request.dto";
+import { AuthResponseDto } from "./dtos/auth.response.dto";
 
-export async function loginAction(data: AuthRequestDto): Promise<void> {
+export async function loginAction(
+  data: AuthRequestDto
+): Promise<void | ApiError> {
+  try {
     const response = await ApiClient.fetch<AuthResponseDto>({
-        method: "POST",
-        path: "/auth/login",
-        body: data,
+      method: "POST",
+      path: "/auth/login",
+      body: data,
     });
 
     if (response.token) {
-        await saveSessionAction(response.token)
+      await saveSessionAction(response.token);
     }
+  } catch (error) {
+    return {
+      name: "LoginError",
+      message:
+        error instanceof Error
+          ? error.message
+          : "An unknown error occurred during login.",
+      statusCode: error instanceof ApiError ? error.statusCode : 500,
+    } as ApiError;
+  }
 }
 
-export async function registerAction(data: AuthRequestDto): Promise<void> {
+export async function registerAction(
+  data: AuthRequestDto
+): Promise<void | ApiError> {
+  try {
     const response = await ApiClient.fetch<AuthResponseDto>({
-        method: "POST",
-        path: "/auth/register",
-        body: data,
+      method: "POST",
+      path: "/auth/register",
+      body: data,
     });
 
     if (response.token) {
-        await saveSessionAction(response.token)
+      await saveSessionAction(response.token);
     }
+  } catch (error) {
+    return {
+      name: "RegisterError",
+      message:
+        error instanceof Error
+          ? error.message
+          : "An unknown error occurred during registration.",
+      statusCode: error instanceof ApiError ? error.statusCode : 500,
+    } as ApiError;
+  }
 }

--- a/apps/web/src/app/actions/shorten-url/shorten-url.action.ts
+++ b/apps/web/src/app/actions/shorten-url/shorten-url.action.ts
@@ -1,15 +1,29 @@
-'use server';
+"use server";
 
+import { ApiError } from "next/dist/server/api-utils";
 import { ApiClient } from "../api/api-client";
 import { ShortenedUrlEntity } from "../entities/shortened-url.entity";
 import { ShortenUrlRequestDto } from "./dtos/shorten-url.request.dto";
 
-export async function shortenUrlAction(data: ShortenUrlRequestDto): Promise<ShortenedUrlEntity> {
+export async function shortenUrlAction(
+  data: ShortenUrlRequestDto
+): Promise<ShortenedUrlEntity | ApiError> {
+  try {
     const response = await ApiClient.fetch<ShortenedUrlEntity>({
-        method: "POST",
-        path: "/url/shorten",
-        body: data,
+      method: "POST",
+      path: "/url/shorten",
+      body: data,
     });
 
     return response;
+  } catch (error) {
+    return {
+        name: "ShortenUrlError",
+        message:
+          error instanceof Error
+            ? error.message
+            : "An unknown error occurred during URL shortening.",
+        statusCode: error instanceof ApiError ? error.statusCode : 500,
+    } as ApiError;
+  }
 }

--- a/apps/web/src/app/auth/components/login-form/login-form.tsx
+++ b/apps/web/src/app/auth/components/login-form/login-form.tsx
@@ -9,13 +9,17 @@ import { AppRoutes } from "@/constants/app-routes";
 import { ApiError } from "next/dist/server/api-utils";
 import { useRouter } from "next/navigation";
 import { loginAction } from "@/app/actions/auth/auth.action";
+import { isStatusCodeError } from "@/lib/api-utils";
 
 interface LoginFormProps {
   onClickRegisterButton: () => void;
   className?: string;
 }
 
-export function LoginForm({ onClickRegisterButton, className }: LoginFormProps) {
+export function LoginForm({
+  onClickRegisterButton,
+  className,
+}: LoginFormProps) {
   const router = useRouter();
   const { setToast } = useToastStore(
     useShallow((state) => ({ setToast: state.setToast }))
@@ -50,10 +54,14 @@ export function LoginForm({ onClickRegisterButton, className }: LoginFormProps) 
     setIsLoading(true);
 
     try {
-      await loginAction({
+      const response = await loginAction({
         email: emailInput.value,
         password: passwordInput.value,
       });
+      const errorResponse = response as ApiError;
+      if (isStatusCodeError(errorResponse.statusCode)) {
+        throw errorResponse;
+      }
 
       setToast({ type: "success", message: "Login successful!" });
 

--- a/apps/web/src/app/auth/components/register-form/register-form.tsx
+++ b/apps/web/src/app/auth/components/register-form/register-form.tsx
@@ -10,6 +10,7 @@ import { ApiError } from "next/dist/server/api-utils";
 import { useRouter } from "next/navigation";
 import { InputValidator } from "@/lib/input-validator";
 import { registerAction } from "@/app/actions/auth/auth.action";
+import { isStatusCodeError } from "@/lib/api-utils";
 
 interface RegisterFormProps {
   onClickLoginButton: () => void;
@@ -71,10 +72,15 @@ export function RegisterForm({ onClickLoginButton, className }: RegisterFormProp
     setIsLoading(true);
 
     try {
-      await registerAction({
+      const response = await registerAction({
         email: emailInput.value,
         password: passwordInput.value,
       });
+
+      const errorResponse = response as ApiError;
+      if (isStatusCodeError(errorResponse.statusCode)) {
+        throw errorResponse;
+      }
 
       setToast({ type: "success", message: "Registration successful!" });
 

--- a/apps/web/src/lib/api-utils.ts
+++ b/apps/web/src/lib/api-utils.ts
@@ -1,0 +1,3 @@
+export const isStatusCodeError = (statusCode: number): boolean => {
+  return statusCode >= 400;
+};


### PR DESCRIPTION
## Description
- NextJS blocks when a server action tries to throw an error to the client side, so it was necessary to return a object of ApiError and validate the success in the client side